### PR TITLE
fix wrong library naming in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ torchvision
 einops
 transformers
 torchaudio
-PyAV
+av


### PR DESCRIPTION
Hello,

While working with your model I ran into an issue with one of the dependencies listed in requirements.txt.
The last line contained PyAV, which caused the following error:
```
ERROR: Could not find a version that satisfies the requirement PyAV (from versions: none)
ERROR: No matching distribution found for PyAV
```
According to the installation instructions in the official PyAV documentation (https://pyav.org/docs/develop/overview/installation.html), the correct package name on PyPI is av. After replacing PyAV with av in requirements.txt, the installation completed successfully.