### PR TITLE
Fix spellings and class naming errors

### DIFF
--- a/data/data_processor.py
+++ b/data/data_processor.py
@@ -89,7 +89,7 @@ class DataProcessor:
         self.img_transform = LongCatImageTransform(univitar_config)
         self.tokenizer = get_tokenizer()
 
-    def _precess_global_vision_info(self, conversations):
+    def _process_global_vision_info(self, conversations):
         config = get_config()
         omni_video_fix_post_pooling_times = config["omni_video_fix_post_pooling_times"]
         omni_video_fix_post_pooling_tokens = config[
@@ -321,7 +321,7 @@ class DataProcessor:
                 "resized_grid_shapes": None,
             }
 
-    def read_vison_and_audio(self, conversations):
+    def read_vision_and_audio(self, conversations):
         for cidx, message in enumerate(conversations):
             content = message["content"]
 
@@ -347,13 +347,13 @@ class DataProcessor:
     def process(self, conversations):
 
         config = get_config()
-        conversations = self.read_vison_and_audio(conversations)
+        conversations = self.read_vision_and_audio(conversations)
         (
             conversations,
             compress_ratio,
             resized_image_token_nums,
             resized_grid_shapes,
-        ) = self._precess_global_vision_info(conversations)
+        ) = self._process_global_vision_info(conversations)
 
         # tokenize
         tokenizer_kwargs = {

--- a/longcat_omni_demo.py
+++ b/longcat_omni_demo.py
@@ -44,7 +44,7 @@ def init_global_config(args):
         # audio
         enable_audio=True,
         max_audio_duration=120,
-        # vison
+        # vision
         video_vit=True,
         max_frame_num=128,
         frame_num=8,
@@ -69,7 +69,7 @@ def create_sglang_engine(args):
     model_path = args.model_path
     sglang_extra_config = dict(
         architectures=["LongcatFlashOmniForCausalLM"],
-        onmi_extra_info=dict(
+        omni_extra_info=dict(
             hf_path=model_path,
             num_multi_ids=config["audio_head_num"],
             audio_head_num=config["audio_head_num"],
@@ -110,7 +110,7 @@ def load_ckpt(model: torch.nn.Module, path: str):
     model.load_state_dict(ckpt)
 
 
-class LoncatOmniInfer:
+class LongCatOmniInfer:
     def __init__(self, args):
         self.node_rank = args.node_rank
         self.config = get_config()
@@ -307,13 +307,13 @@ def main():
         type=str,
         default="cuda",
         choices=["cuda", "cpu"],
-        help="The placement device of the modailty encoder",
+        help="The placement device of the modality encoder",
     )
     args = parser.parse_args()
     init_global_config(args)
 
     os.makedirs(args.output_dir, exist_ok=True)
-    infer_engine = LoncatOmniInfer(args)
+    infer_engine = LongCatOmniInfer(args)
     sampling_params = {
         "temperature": 1,
         "max_new_tokens": 4096,


### PR DESCRIPTION
Fixes several typos and naming inconsistencies found in the project. The main changes include correcting the class name LoncatOmniInfer to LongCatOmnilnfer, fixing the function name typo precess_to process, and correcting various comment typos such as vison and modailty.